### PR TITLE
Fix DB init files

### DIFF
--- a/docker/my-dojo/mysql/Dockerfile
+++ b/docker/my-dojo/mysql/Dockerfile
@@ -11,3 +11,6 @@ RUN     chmod u+x /update-db.sh && \
 
 # Copy content of mysql scripts into /docker-entrypoint-initdb.d
 COPY    ./db-scripts/ /docker-entrypoint-initdb.d
+
+# Remove template extension from SQL init schema
+RUN     bash -c 'for f in /docker-entrypoint-initdb.d/*.tpl; do mv -- "$f" "${f%.tpl}"; done'


### PR DESCRIPTION
Since [this commit](https://code.samourai.io/dojo/samourai-dojo/-/commit/e3d515f7096f5b5350bdcc69ad1cf1f5afa5dfee) Dojo switched to using the .tpl extension for all it's config files which is stripped out as part of the install/update process.

This container was just copying the DB init directory in without changes so it contained *.sql.tpl files instead of *.sql files which then weren't being loaded by the MariaDB setup process, resulting in all users of this image having an empty DB.

Currently template files don't really contain any templating so we can simply be remove the .tpl extension and everything works. However we should keep an eye on this because if the templates ever include any templating logic in the future this will break again.